### PR TITLE
Use new RSpec syntax

### DIFF
--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ describe SessionsController, :omniauth do
     end
 
     it "resets the session" do
-      session[:user_id].should_not be_nil
+      expect(session[:user_id]).not_to be_nil
       delete :destroy
       expect(session[:user_id]).to be_nil
     end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -11,8 +11,8 @@ feature 'Sign in', :omniauth do
   #   Then I see a success message
   scenario "user can sign in with valid account" do
     signin
-    page.should have_content("test@example.com")
-    page.should have_content("Sign out")
+    expect(page).to have_content("test@example.com")
+    expect(page).to have_content("Sign out")
   end
 
   # Scenario: User cannot sign in with invalid account
@@ -23,9 +23,9 @@ feature 'Sign in', :omniauth do
   scenario 'user cannot sign in with invalid account' do
     OmniAuth.config.mock_auth[:twitter] = :invalid_credentials
     visit root_path
-    page.should have_content("Sign in")
+    expect(page).to have_content("Sign in")
     click_link "Sign in"
-    page.should have_content('Authentication error')
+    expect(page).to have_content('Authentication error')
   end
 
 end

--- a/spec/support/helpers/omniauth.rb
+++ b/spec/support/helpers/omniauth.rb
@@ -20,7 +20,7 @@ module Omniauth
   module SessionHelpers
     def signin
       visit root_path
-      page.should have_content("Sign in")
+      expect(page).to have_content("Sign in")
       auth_mock
       click_link "Sign in"
       fill_in 'user_email', with: 'test@example.com'


### PR DESCRIPTION
Fixes this deprecation warning when running the specs:

```
Using `should_not` from rspec-expectations' old `:should` syntax without
explicitly enabling the syntax is deprecated. Use the new `:expect` syntax
or explicitly enable `:should` instead.
```
