### PR TITLE
Change 'signin' to 'sign_in'

### DIFF
--- a/app/views/layouts/_navigation_links.html.erb
+++ b/app/views/layouts/_navigation_links.html.erb
@@ -1,7 +1,7 @@
 <%# add navigation links to this file %>
 <li><%= link_to 'About', page_path('about') %></li>
 <% if user_signed_in? %>
-  <li><%= link_to 'Sign out', signout_path %></li>
+  <li><%= link_to 'Sign out', sign_out_path %></li>
 <% else %>
-  <li><%= link_to 'Sign in', signin_path %></li>
+  <li><%= link_to 'Sign in', sign_in_path %></li>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   root :to => "visitors#index"
   resources :users, :only => [:index, :show, :edit, :update ]
   get '/auth/:provider/callback' => 'sessions#create'
-  get '/signin' => 'sessions#new', :as => :signin
-  get '/signout' => 'sessions#destroy', :as => :signout
+  get '/sign_in' => 'sessions#new', :as => :sign_in
+  get '/sign_out' => 'sessions#destroy', :as => :sign_out
   get '/auth/failure' => 'sessions#failure'
 end

--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -10,7 +10,7 @@ feature 'Sign in', :omniauth do
   #   When I sign in
   #   Then I see a success message
   scenario "user can sign in with valid account" do
-    signin
+    sign_in
     expect(page).to have_content("test@example.com")
     expect(page).to have_content("Sign out")
   end

--- a/spec/features/users/sign_out_spec.rb
+++ b/spec/features/users/sign_out_spec.rb
@@ -9,7 +9,7 @@ feature 'Sign out', :omniauth do
   #   When I sign out
   #   Then I see a signed out message
   scenario 'user signs out successfully' do
-    signin
+    sign_in
     click_link 'Sign out'
     expect(page).to have_content 'Signed out'
   end

--- a/spec/support/helpers/omniauth.rb
+++ b/spec/support/helpers/omniauth.rb
@@ -18,7 +18,7 @@ module Omniauth
   end
 
   module SessionHelpers
-    def signin
+    def sign_in
       visit root_path
       expect(page).to have_content("Sign in")
       auth_mock


### PR DESCRIPTION
This increases readability and makes it consistent with the
use in plain English and also in the spec filenames.
