### PR TITLE
Why 'where' message?

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,7 @@ class SessionsController < ApplicationController
 
   def create
     auth = request.env["omniauth.auth"]
-    user = User.where(:provider => auth['provider'],
-                      :uid => auth['uid'].to_s).first || User.create_with_omniauth(auth)
+    user = User.find_by(provider: auth['provider'], uid: auth['uid']) || User.create_with_omniauth(auth)
     reset_session
     session[:user_id] = user.id
     redirect_to root_url, :notice => 'Signed in!'


### PR DESCRIPTION
I don't understand cause use 'where' message when find_by message it's ok.

It is also more readable than before.